### PR TITLE
make sure that settings customizations is applied even if middleware is disabled

### DIFF
--- a/Vostok.Applications.AspNetCore/Builders/VostokMiddlewaresBuilder.cs
+++ b/Vostok.Applications.AspNetCore/Builders/VostokMiddlewaresBuilder.cs
@@ -135,10 +135,10 @@ namespace Vostok.Applications.AspNetCore.Builders
             if (preVostokMiddlewares.TryGetValue(typeof(TMiddleware), out var injected))
                 middlewares.AddRange(injected);
 
+            services.Configure<TSettings>(settings => customization.Customize(settings));
+
             if (IsEnabled<TMiddleware>())
             {
-                services.Configure<TSettings>(settings => customization.Customize(settings));
-
                 middlewares.Add(typeof(TMiddleware));
             }
         }


### PR DESCRIPTION
Наступил на это с тротлингом: настраиваю тротлинг методом SetupThrottling, отключаю ThrottlingMiddleware чтобы явно использовать `UseVostokThrottling()` в том месте, где мне надо в pipeline, но при этом то, что настраивал в SetupThrottling не применяется.